### PR TITLE
dictionary 만들기, append + join, 조건문 조정

### DIFF
--- a/engToKor/views.py
+++ b/engToKor/views.py
@@ -1,25 +1,50 @@
 from django.shortcuts import render, redirect
 from hangul_utils import join_jamos
 import re
-
-# HardCoding Values
-consonant_english_lower = ['q', 'w', 'e', 'r', 't', 'a', 's', 'd', 'f', 'g', 'z', 'x', 'c', 'v', 'b']
-consonant_english_upper = ['Q', 'W', 'E', 'R', 'T']
+   
 vowels_english_lower = ['y', 'u', 'i', 'o', 'p', 'h', 'j', 'k', 'l', 'b', 'n', 'm']
 vowels_english_upper = ['O', 'P']
-consonant_korean_lower = ['ㅂ', 'ㅈ', 'ㄷ', 'ㄱ', 'ㅅ', 'ㅁ', 'ㄴ', 'ㅇ', 'ㄹ', 'ㅎ', 'ㅋ', 'ㅌ', 'ㅊ', 'ㅍ']
-consonant_korean_upper = ['ㅃ', 'ㅉ', 'ㄸ', 'ㄲ', 'ㅆ']
+
 vowels_korean_lower = ['ㅛ', 'ㅕ', 'ㅑ', 'ㅐ', 'ㅔ', 'ㅗ', 'ㅓ', 'ㅏ', 'ㅣ', 'ㅠ', 'ㅜ', 'ㅡ']
 vowels_korean_upper = ['ㅒ', 'ㅖ']
+
+consonant_english_lower = ['q', 'w', 'e', 'r', 't', 'a', 's', 'd', 'f', 'g', 'z', 'x', 'c', 'v', 'b']
+consonant_english_upper = ['Q', 'W', 'E', 'R', 'T']
+
+consonant_korean_lower = ['ㅂ', 'ㅈ', 'ㄷ', 'ㄱ', 'ㅅ', 'ㅁ', 'ㄴ', 'ㅇ', 'ㄹ', 'ㅎ', 'ㅋ', 'ㅌ', 'ㅊ', 'ㅍ']
+consonant_korean_upper = ['ㅃ', 'ㅉ', 'ㄸ', 'ㄲ', 'ㅆ']
+
+# 사전 만들기
+def to_dict(eng_dict, kor_dict):
+    {e:k for e, k in zip(eng_dict, kor_dict)}
+
+vowels_lower_dict = to_dict(vowels_english_lower, vowels_korean_lower)
+vowels_upper_dict = to_dict(vowels_english_upper, vowels_korean_upper)
+
+consonant_lower_dict = to_dict(consonant_english_lower, consonant_korean_lower)
+consonant_upper_dict = to_dict(consonant_english_upper, consonant_korean_upper)
+
+# 사전 합치기
+eng_to_kor_dict = {**vowels_lower_dict, **vowels_upper_dict, **consonant_lower_dict, **consonant_upper_dict}
+
 stop_vowels = ['h', 'n', 'm']
 check_vowels = ['k', 'o', 'j', 'p', 'l']
-comb_vowels = {'ㅘ': ['h', 'k'], 'ㅙ': ['h', 'o'], 'ㅝ': ['n', 'j'], 'ㅞ': ['n', 'p'], 'ㅚ': ['h', 'l'],
-               'ㅟ': ['n', 'l'], 'ㅢ': ['m', 'l']}
+
+# tuple은 hash key로 쓸 수 있어서, 역 테이블을 만들 수 있다.
+comb_vowels = {'ㅘ': ('h', 'k'), 'ㅙ': ('h', 'o'),'ㅝ': ('n', 'j'), 'ㅞ': ('n', 'p'), 'ㅚ': ('h', 'l'), 'ㅟ': ('n', 'l'), 'ㅢ': ('m', 'l')}
+
+def get_reverse(a_dict):
+    return {value:key for key, value in a_dict.items()}
+
+re_comb_vowels = get_reverse(comb_vowels)
+
 stop_consonants = ['r', 's', 'f', 'q']
 check_consonants = ['t', 'w', 'g', 'r', 'a', 'q', 'x', 'v', 'g']
-comb_consonants = {'ㄳ': ['r', 't'], 'ㄵ': ['s', 'w'], 'ㄶ': ['s', 'g'], 'ㄺ': ['f', 'r'], 'ㄻ': ['f', 'a'], 'ㄼ': ['f', 'q'],
-                   'ㄽ': ['f', 't'], 'ㄾ': ['f', 'x'], 'ㄿ': ['f', 'v'], 'ㅀ': ['f', 'g'], 'ㅄ': ['q', 't']}
 
+comb_consonants = {'ㄳ': ('r', 't'), 'ㄵ': ('s', 'w'), 'ㄶ': ('s', 'g'), 'ㄺ': ('f', 'r'), 'ㄻ': ('f', 'a'), 'ㄼ': ('f', 'q'),
+                    'ㄽ': ('f', 't'), 'ㄾ': ('f', 'x'), 'ㄿ': ('f', 'v'), 'ㅀ': ('f', 'g'), 'ㅄ': ('q', 't')}
+
+re_comb_consonants = get_reverse(comb_consonants)
 
 def index(request):
     return render(request, 'index.html')
@@ -41,61 +66,35 @@ def convert(request):
 
 
 def typo_to_kor_char(typos):
-    jamo = ''
+    jamo = []
     i = 0
     while i < len(typos):
+        new, special = '', ''
         if typos[i] in stop_vowels and typos[i + 1] in check_vowels:
-            special_vowel = convert_english_to_korean_special_vowels([typos[i], typos[i + 1]])
-            if special_vowel:
-                jamo += special_vowel
-                i += 2
-                continue
+            comb = (typos[i], typos[i + 1])
+            special = special_vowels(comb)
         elif typos[i] in stop_consonants and typos[i + 1] in check_consonants:
             if typos[i+2] in vowels_english_upper or typos[i+2] in vowels_english_lower:
-                jamo += convert_english_to_korean(typos[i])
-                i += 1
-                continue
-            special_consonant = convert_english_to_korean_special_consonants([typos[i], typos[i + 1]])
-            if special_consonant:
-                jamo += special_consonant
-                i += 2
-                continue
-        jamo += convert_english_to_korean(typos[i])
-        i += 1
-    return jamo
+                new = convert_english_to_korean(typos[i])
+            comb = (typos[i+len(new)], typos[i+len(new) + 1])
+            special = special_consonants(comb)
+        else:
+            new = convert_english_to_korean(typos[i])
+            
+        i += len(new) + len(special) * 2
+        jamo.append(new + special)
+        
+    # 문자열을 더하는 것보다 append하고 join하는 게 더 빠릅니다. 파이썬 공식 문서에서 추천하는 방법.
+    return "".join(jamo)
 
-def convert_english_to_korean_special_vowels(word_list):
-    for key, value in comb_vowels.items():
-        if word_list == value:
-            return key
-    else:
-        return ''
+def special_vowels(word_tup):
+    return re_comb_vowels.get(word_tup, '')
 
-
-def convert_english_to_korean_special_consonants(word_list):
-    for key, value in comb_consonants.items():
-        if word_list == value:
-            return key
-    else:
-        return ''
-
+def special_consonants(word_tup):
+    return re_comb_consonants.get(word_tup, '')
 
 def convert_english_to_korean(eng):
-    if eng in consonant_english_lower:
-        index = consonant_english_lower.index(eng)
-        return consonant_korean_lower[index]
-    elif eng in consonant_english_upper:
-        index = consonant_english_upper.index(eng)
-        return consonant_korean_upper[index]
-    elif eng in vowels_english_lower:
-        index = vowels_english_lower.index(eng)
-        return vowels_korean_lower[index]
-    elif eng in vowels_english_upper:
-        index = vowels_english_upper.index(eng)
-        return vowels_korean_upper[index]
-    else:
-        return eng
-
+    return eng_to_kor_dict.get(eng, eng)  # key로 값을 찾아오고, 없으면 디폴트로 eng를 반환
 
 # reference: https://m.blog.naver.com/PostView.nhn?blogId=chandong83&logNo=221142971719&proxyReferer=https:%2F%2Fwww.google.com%2F
 def isHangul(text):


### PR DESCRIPTION
한글이 참 다루기 어렵네요! 얼마나 고생하셨을지 상상도 가지 않습니다.

제가 아는 파이썬 문법 몇 가지로 리팩토링을 해봤습니다. 주석으로도 적었지만 다시 정리해보면 이렇습니다.

### 튜플은 key로 쓸 수 있습니다.
리스트는 mutable하기 때문에, key로 만들 수가 없습니다. comb 를 찾을 때 그래서 for문을 쓰셨는데요. 이 알고리즘이 비효율적이라는 건 알고 계실 겁니다. 그러면 어떻게 딕셔너리를 쓸 수 있을까요? 네. 제목이 곧 답입니다.

저는 만드신 딕셔너리를 {key: tuple(value) for key, value in a_dict.items()}를 써서 변환했습니다. 그렇게 나온 값을 다시 하드 코딩해서 넣었죠.

### 컴프리헨션을 쓰면 역 리스트를 쉽게 만들 수 있습니다.
어떤 딕셔너리의 value를 가지고 key를 찾고 싶을 때가 있으실 겁니다. 이걸 get_reverse함수로 만들었습니다. 역시 컴프리헨션을 쓰면 아주 쉽습니다. (솔직히 이건 내장 함수가 있을 법도 한데 귀찮아서 안 찾아봤습니다)

### append와 join으로 문자열을 합쳤습니다.
+= 으로 문자열을 합치는 건 매우 느린 연산입니다. python에서 문자열은 immutable 불변이기 때문입니다. 그래서 합친 문자열을 매번 처음부터 새로 만듭니다!
그래서 mutable한 리스트에 하나하나 차곡차곡 담아놓고, join으로 합치는 게 더 빠릅니다. python 공식 문서에서도 추천하는 방법이죠.

### 반복되는 if 문과 i += 연산을 합쳤습니다.
값이 있는지 체크하는 if문은 대부분 제거할 수 있는 방법이 있습니다. 머리를 잘 굴려보니, 결국 i는 이번에 만든 글자 수 만큼 앞으로 나아갑니다. 다만 특이한 부분은 special하게 겹 자음, 겹 모음인 경우죠. 그래서 이 둘을 구분해서 new와 special로 나눴습니다.

그러면 매번 경우에 따라 하드 코딩할 필요 없이, 단 한 줄로 처리할 수 있습니다.

다만 테스트 해보니 하나 특이한 부분이 있었는데, 바로 special_consonant였습니다. 이 경우 앞의 if문의 결과에 따라 +1 한 칸 앞으로 전진했어야 하니까요. 이 부분은 +len(new)라는 편법을 썼습니다만, 아쉬움이 남긴 합니다.

그 밖에도 리팩토링할 수 있는 부분들이 보이긴 하는데요. 이건 또 다른 pull request로 걸겠습니다. 멋진 작업 감사합니다. 앞으로 계속 나아가시길 기원합니다. 👍 